### PR TITLE
Use cleaner if-statement syntax in bash/zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,12 +899,12 @@ export PATH="$HOME/.dotbins/$_os/$_arch/bin:$PATH"
 
 # Tool-specific configurations
 # Configuration for fzf
-if command -v fzf >/dev/null 2>&1; then
+if command -v fzf &> /dev/null; then
     source <(fzf --zsh)
 fi
 
 # Configuration for bat
-if command -v bat >/dev/null 2>&1; then
+if command -v bat &> /dev/null; then
     alias bat="bat --paging=never"
     alias cat="bat --plain --paging=never"
 fi

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -143,7 +143,7 @@ def _format_shell_instructions(
             export PATH="{tools_dir_str}/$_os/$_arch/bin:$PATH"
             """,
         )
-        if_start = "if command -v {name} >/dev/null 2>&1; then"
+        if_start = "if command -v {name} &> /dev/null; then"
         if_end = "fi"
         base_script += _add_shell_code_to_script(tools, shell, if_start, if_end)
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1646,7 +1646,7 @@ def test_tool_shell_code_in_shell_scripts(
         if shell in ("bash", "zsh"):
             # Check tools with shell_code
             for tool in ["fzf", "zoxide", "eza", "starship"]:
-                assert f"if command -v {tool} >/dev/null 2>&1; then" in content
+                assert f"if command -v {tool} &> /dev/null; then" in content
 
             # Verify specific shell code for each tool
             assert "source <(fzf --zsh)" in content
@@ -1660,7 +1660,7 @@ def test_tool_shell_code_in_shell_scripts(
                 assert 'eval "$(starship init zsh)"' in content
 
             # Check tool without shell_code has no block
-            assert "if command -v bat >/dev/null 2>&1; then" not in content
+            assert "if command -v bat &> /dev/null; then" not in content
 
         elif shell == "fish":
             # Check tools with shell_code (fish syntax)


### PR DESCRIPTION
EDIT:

**`&>` redirection compatibility:**

1. **Zsh**: Supported in all modern versions, including older ones 
2. **Bash**: Only supported in Bash 4.0+ (released in 2009)
   - Notable exception: macOS shipped with Bash 3.2 until 2019 (Catalina), which does NOT support `&>`
3. **POSIX sh and other shells**: Not supported

**For maximum compatibility across shells and older versions:**
```bash
if command -v direnv >/dev/null 2>&1; then
```

**For modern Zsh/Bash systems only:**
```bash
if command -v direnv &> /dev/null; then
```
