### PR TITLE
fix(nushell): Correct integration script generation for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -956,7 +956,7 @@ source "$HOME/.dotbins/shell/bash.sh"
 source "$HOME/.dotbins/shell/fish.fish"
 
 # For Nushell
-source $env.HOME/.dotbins/shell/nushell.nu
+source ~/.dotbins/shell/nushell.nu
 ```
 
 ---

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -290,11 +290,16 @@ def write_shell_scripts(
     log(f"Generated shell scripts in {tools_dir1}/shell/", "success", "📝")
     if print_shell_setup:
         tools_dir2 = replace_home_in_path(tools_dir, "$HOME")
+        tools_dir2_nu = tools_dir2.replace("$HOME", "($nu.home-path)")
         log("Add this to your shell config:", "info")
         log(f"  [b]Bash:[/]       [yellow]source {tools_dir2}/shell/bash.sh[/]", "info", "👉")
         log(f"  [b]Zsh:[/]        [yellow]source {tools_dir2}/shell/zsh.sh[/]", "info", "👉")
         log(f"  [b]Fish:[/]       [yellow]source {tools_dir2}/shell/fish.fish[/]", "info", "👉")
-        log(f"  [b]Nushell:[/]    [yellow]source {tools_dir2}/shell/nushell.nu[/]", "info", "👉")
+        log(
+            f'  [b]Nushell:[/]    [yellow]source $"{tools_dir2_nu}/shell/nushell.nu"[/]',
+            "info",
+            "👉",
+        )
         log(f"  [b]PowerShell:[/] [yellow]. {tools_dir2}/shell/powershell.ps1[/]", "info", "👉")
 
 

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -183,15 +183,16 @@ def _format_shell_instructions(
         return base_script
 
     if shell == "nushell":
+        tools_dir_str_nu = tools_dir_str.replace("$HOME", "($nu.home-path)")
         script_lines = [
             "# dotbins - Add platform-specific binaries to PATH",
-            "let _os = (sys).host.name | str downcase",
+            "let _os = sys host | get name | str downcase",
             'let _os = if $_os == "darwin" { "macos" } else { $_os }',
             "",
-            "let _arch = (sys).host.arch",
+            "let _arch = sys host | get arch",
             'let _arch = if $_arch == "x86_64" { "amd64" } else if $_arch in ["aarch64", "arm64"] { "arm64" } else { $_arch }',
             "",
-            f'$env.PATH = ($env.PATH | prepend $"{tools_dir_str}/$_os/$_arch/bin")',
+            f'$env.PATH = ($env.PATH | prepend $"{tools_dir_str_nu}/($_os)/($_arch)/bin")',
         ]
         base_script = "\n".join(script_lines)
         if_start = "if (which {name}) != null {{"

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -186,10 +186,10 @@ def _format_shell_instructions(
         tools_dir_str_nu = tools_dir_str.replace("$HOME", "($nu.home-path)")
         script_lines = [
             "# dotbins - Add platform-specific binaries to PATH",
-            "let _os = sys host | get name | str downcase",
+            "let _os = $nu.os-info | get name",
             'let _os = if $_os == "darwin" { "macos" } else { $_os }',
             "",
-            "let _arch = sys host | get arch",
+            "let _arch = $nu.os-info | get arch",
             'let _arch = if $_arch == "x86_64" { "amd64" } else if $_arch in ["aarch64", "arm64"] { "arm64" } else { $_arch }',
             "",
             f'$env.PATH = ($env.PATH | prepend $"{tools_dir_str_nu}/($_os)/($_arch)/bin")',

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -290,16 +290,12 @@ def write_shell_scripts(
     log(f"Generated shell scripts in {tools_dir1}/shell/", "success", "📝")
     if print_shell_setup:
         tools_dir2 = replace_home_in_path(tools_dir, "$HOME")
-        tools_dir2_nu = tools_dir2.replace("$HOME", "($nu.home-path)")
+        tools_dir2_nu = tools_dir2.replace("$HOME", "~")
         log("Add this to your shell config:", "info")
         log(f"  [b]Bash:[/]       [yellow]source {tools_dir2}/shell/bash.sh[/]", "info", "👉")
         log(f"  [b]Zsh:[/]        [yellow]source {tools_dir2}/shell/zsh.sh[/]", "info", "👉")
         log(f"  [b]Fish:[/]       [yellow]source {tools_dir2}/shell/fish.fish[/]", "info", "👉")
-        log(
-            f'  [b]Nushell:[/]    [yellow]source $"{tools_dir2_nu}/shell/nushell.nu"[/]',
-            "info",
-            "👉",
-        )
+        log(f"  [b]Nushell:[/]    [yellow]source {tools_dir2_nu}/shell/nushell.nu[/]", "info", "👉")
         log(f"  [b]PowerShell:[/] [yellow]. {tools_dir2}/shell/powershell.ps1[/]", "info", "👉")
 
 


### PR DESCRIPTION
This fixes issues with the generated `nushell.nu` integration script, primarily reported on Windows but improving cross-platform compatibility for Nushell users.

**Problem:**

Users on Windows encountered errors when sourcing the `nushell.nu` script:
1.  Incorrect syntax `(sys).host.name` and `(sys).host.arch` resulted in `Error: nu::shell::incompatible_path_access`.
2.  The PATH construction line using `$HOME` and standard f-string interpolation resulted in incorrect paths like `$env.HOMEPATH/...` instead of expanding the home directory correctly within Nushell.

Hopefully this fixes it.

Fixes #99 and #100, thanks to @buzmakov!