### PR TITLE
Ensure CLI help shows dotbins

### DIFF
--- a/dotbins/cli.py
+++ b/dotbins/cli.py
@@ -133,6 +133,7 @@ def _get_tool(
 def create_parser() -> argparse.ArgumentParser:
     """Create command-line argument parser."""
     parser = argparse.ArgumentParser(
+        prog="dotbins",
         description="dotbins - Download, manage, and update CLI tool binaries in your dotfiles repository",
         formatter_class=RichHelpFormatter,
     )


### PR DESCRIPTION
## Summary
- set the argparse parser prog to `dotbins` so the help text matches Windows CI

## Testing
- PYTEST_ADDOPTS=--no-cov pytest tests/test_cli.py::test_cli_no_command