### PR TITLE
docs: Remove duplicate 'Multiple Binaries' section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,17 +215,6 @@ When requesting Windows x86_64 and both of these assets are available:
 With `windows_abi="msvc"`, dotbins selects the MSVC version.
 With `windows_abi="gnu"`, dotbins selects the GNU version.
 
-## Multiple Binaries
-
-For tools that provide multiple binaries:
-
-```yaml
-uv:
-  repo: astral-sh/uv
-  binary_name: [uv, uvx]
-  path_in_archive: [uv-*/uv, uv-*/uvx]
-```
-
 ## Configuration Examples
 
 ### Minimal Tool Configuration


### PR DESCRIPTION
## Summary
Remove duplicate content in configuration.md:
- The `## Multiple Binaries` section (with uv example) was redundant
- The same uv example already appears in `### Tool with Multiple Binaries` under Configuration Examples

## Review Notes
This was found during a documentation review for balance and duplicates.