### PR TITLE
Add api_url option for non-GitHub forges

### DIFF
--- a/dotbins/config.py
+++ b/dotbins/config.py
@@ -333,6 +333,7 @@ class ToolConfig:
     arch_map: dict[str, str] = field(default_factory=dict)
     shell_code: dict[str, str] = field(default_factory=dict)
     defaults: DefaultsDict = field(default_factory=lambda: DEFAULTS.copy())
+    api_url: str | None = None
     _release_info: dict | None = field(default=None, init=False)
 
     def bin_spec(self, arch: str, platform: str) -> BinSpec:
@@ -456,6 +457,7 @@ class RawToolConfigDict(TypedDict, total=False):
     shell_code: str | dict[str, str] | None  # Shell code to configure the tool
     tag: str | None  # Tag to use for the binary (if None, the latest release will be used)
     tag_pattern: str | None  # Regex to filter releases (e.g., "^cli-" for bitwarden/clients)
+    api_url: str | None  # Base API URL for non-GitHub forges (e.g., "https://gitea.com/api/v1")
 
 
 class _AssetDict(TypedDict):
@@ -496,6 +498,7 @@ def build_tool_config(
         tag = None
 
     tag_pattern: str | None = raw_data.get("tag_pattern")  # type: ignore[assignment]
+    api_url: str | None = raw_data.get("api_url")  # type: ignore[assignment]
 
     # Convert to lists
     binary_name: list[str] = _ensure_list(raw_binary_name)
@@ -523,6 +526,7 @@ def build_tool_config(
         arch_map=arch_map,
         shell_code=shell_code,
         defaults=defaults,
+        api_url=api_url,
     )
 
 
@@ -975,6 +979,7 @@ def _fetch_release(
             tool_config.tag,
             tool_config.tag_pattern,
             github_token,
+            api_url=tool_config.api_url,
         )
         tool_config._release_info = release_info
     except Exception as e:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from dotbins.config import Config, build_tool_config
+from dotbins.config import Config, _config_from_dict, build_tool_config
 
 
 def test_validate_unknown_architecture(capsys: pytest.CaptureFixture[str]) -> None:
@@ -119,3 +119,38 @@ def test_asset_patterns_uses_unknown_arch() -> None:
         },
     }
     config.validate()
+
+
+def test_api_url_from_config_dict() -> None:
+    """Test that api_url is correctly parsed from config dict."""
+    config = _config_from_dict(
+        {
+            "tools": {
+                "tea": {
+                    "repo": "gitea/tea",
+                    "api_url": "https://gitea.com/api/v1",
+                },
+                "fzf": "junegunn/fzf",
+            },
+        },
+    )
+    assert config.tools["tea"].api_url == "https://gitea.com/api/v1"
+    assert config.tools["fzf"].api_url is None
+
+
+def test_api_url_in_build_tool_config() -> None:
+    """Test that api_url is correctly set via build_tool_config."""
+    tool = build_tool_config(
+        tool_name="tea",
+        raw_data={"repo": "gitea/tea", "api_url": "https://gitea.com/api/v1"},
+    )
+    assert tool.api_url == "https://gitea.com/api/v1"
+
+
+def test_api_url_defaults_to_none() -> None:
+    """Test that api_url defaults to None when not specified."""
+    tool = build_tool_config(
+        tool_name="fzf",
+        raw_data={"repo": "junegunn/fzf"},
+    )
+    assert tool.api_url is None

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -587,6 +587,7 @@ def test_get_tool_command(tmp_path: Path, create_dummy_archive: Callable) -> Non
         tag: str | None = None,  # noqa: ARG001
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
+        api_url: str | None = None,  # noqa: ARG001
     ) -> dict:
         return {
             "tag_name": "v1.0.0",
@@ -704,6 +705,7 @@ def test_get_tool_command_with_remote_config(
         tag: str | None = None,  # noqa: ARG001
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
+        api_url: str | None = None,  # noqa: ARG001
     ) -> dict:
         log(f"Getting release info for repo: {repo}", "info")
         tool_name = repo.split("/")[-1]
@@ -774,6 +776,7 @@ def test_get_tool_command_with_local_config(
         tag: str | None = None,  # noqa: ARG001
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
+        api_url: str | None = None,  # noqa: ARG001
     ) -> dict:
         log(f"Getting release info for repo: {repo}", "info")
         tool_name = repo.split("/")[-1]


### PR DESCRIPTION
## Summary

- Adds `api_url` config option to `ToolConfig` for specifying a custom API base URL
- Supports any forge with a GitHub-compatible releases API (Gitea, Forgejo, Gogs, GitHub Enterprise)
- Defaults to `https://api.github.com` when not specified, so no breaking changes

**Example config:**
```yaml
tools:
  tea:
    repo: gitea/tea
    api_url: https://gitea.com/api/v1
```

Closes #156

## Test plan
- [x] All existing tests pass (438 → 446 with new tests)
- [x] New tests verify URL construction for latest, tagged, and tag_pattern requests
- [x] New tests verify config parsing (`api_url` from dict, defaults to `None`)
- [x] Trailing slash handling tested
- [x] Lint clean