### PR TITLE
Fix __DOTBINS_SHELL__ replacement in generic shell_code

### DIFF
--- a/dotbins/config.py
+++ b/dotbins/config.py
@@ -675,7 +675,7 @@ def _normalize_shell_code(
 
     if isinstance(raw_shell_code, str):
         for shell in SUPPORTED_SHELLS:
-            normalized[shell] = raw_shell_code
+            normalized[shell] = raw_shell_code.replace("__DOTBINS_SHELL__", shell)
     elif isinstance(raw_shell_code, dict):
         for shell_key, code in raw_shell_code.items():
             shells = [s.strip() for s in shell_key.split(",") if s.strip()]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -548,6 +548,25 @@ def test_build_tool_config_skips_unknown_platforms() -> None:
     }
 
 
+def test_build_tool_config_replaces_placeholder_in_generic_shell_code() -> None:
+    """Test that generic shell_code strings replace __DOTBINS_SHELL__ for each shell."""
+    tool_config = build_tool_config(
+        tool_name="tool",
+        raw_data={
+            "repo": "test/repo",
+            "shell_code": 'echo "__DOTBINS_SHELL__"',
+        },
+    )
+
+    assert tool_config.shell_code == {
+        "bash": 'echo "bash"',
+        "zsh": 'echo "zsh"',
+        "fish": 'echo "fish"',
+        "nushell": 'echo "nushell"',
+        "powershell": 'echo "powershell"',
+    }
+
+
 def test_extract_from_archive_with_arch_platform_version_in_path(
     tmp_path: Path,
     create_dummy_archive: Callable,


### PR DESCRIPTION
## Summary
- replace `__DOTBINS_SHELL__` for generic string `shell_code` entries across all supported shells
- keep the existing per-shell mapping behavior unchanged
- add a regression test covering the generic `shell_code: |` placeholder case

## Testing
- `uv run pytest --no-cov tests/test_unit.py -k generic_shell_code`
- `uv run pytest --no-cov tests/test_e2e.py -k "tool_shell_code_in_shell_scripts or tool_with_custom_shell_code"`
- `uv run ruff check dotbins/config.py tests/test_unit.py`

Closes #169