### PR TITLE
Make sync progress logging verbose-only

### DIFF
--- a/dotbins/config.py
+++ b/dotbins/config.py
@@ -213,18 +213,20 @@ class Config:
             return
 
         if github_token is None and "GITHUB_TOKEN" in os.environ:  # pragma: no cover
-            log("Using GitHub token for authentication", "info", "🔑")
+            if verbose:
+                log("Using GitHub token for authentication", "info", "🔑")
             github_token = os.environ["GITHUB_TOKEN"]
 
         if pin_to_manifest:
             tool_to_tag_mapping = self.manifest.tool_to_tag_mapping()
             for tool, tool_config in self.tools.items():
                 tag = tool_to_tag_mapping.get(tool)
-                log(
-                    f"Using tag [b]{tag}[/] for tool [b]{tool}[/] from [b]manifest.json[/]",
-                    "info",
-                    "🔒",
-                )
+                if verbose:
+                    log(
+                        f"Using tag [b]{tag}[/] for tool [b]{tool}[/] from [b]manifest.json[/]",
+                        "info",
+                        "🔒",
+                    )
                 tool_config.tag = tag
 
         tools_to_sync = _tools_to_sync(self, tools)
@@ -260,7 +262,7 @@ class Config:
             self.generate_readme(verbose=verbose)
         if generate_shell_scripts:
             self.generate_shell_scripts(print_shell_setup=False)
-        _maybe_copy_config_file(copy_config_file, self.config_path, self.tools_dir)
+        _maybe_copy_config_file(copy_config_file, self.config_path, self.tools_dir, verbose)
 
     def generate_shell_scripts(self: Config, print_shell_setup: bool = True) -> None:
         """Generate shell script files for different shells.
@@ -276,6 +278,7 @@ def _maybe_copy_config_file(
     copy_config_file: bool,
     config_path: Path | None,
     tools_dir: Path,
+    verbose: bool = False,
 ) -> None:
     if not copy_config_file or config_path is None:
         return
@@ -290,7 +293,8 @@ def _maybe_copy_config_file(
         is_same = cfg1 == cfg2
         if is_same:
             return
-    log("Copying config to tools directory as `dotbins.yaml`", "info")
+    if verbose:
+        log("Copying config to tools directory as `dotbins.yaml`", "info")
     shutil.copy(config_path, tools_config_path)
 
 
@@ -377,7 +381,7 @@ class BinSpec:
         """Get the platform in the tool's convention."""
         return self.tool_config.platform_map.get(self.platform, self.platform)
 
-    def asset_pattern(self) -> str | None:
+    def asset_pattern(self, verbose: bool = False) -> str | None:
         """Get the formatted asset pattern for the tool."""
         return _maybe_asset_pattern(
             self.tool_config,
@@ -386,11 +390,12 @@ class BinSpec:
             self.tag,
             self.tool_platform,
             self.tool_arch,
+            verbose,
         )
 
-    def matching_asset(self) -> _AssetDict | None:
+    def matching_asset(self, verbose: bool = False) -> _AssetDict | None:
         """Find a matching asset for the tool."""
-        asset_pattern = self.asset_pattern()
+        asset_pattern = self.asset_pattern(verbose)
         assert self.tool_config._release_info is not None
         assets = self.tool_config._release_info["assets"]
         if asset_pattern is None:
@@ -401,10 +406,11 @@ class BinSpec:
                 self.tool_config.defaults,
                 self.tool_config.tool_name,
                 self.tool_config.repo.rsplit("/", 1)[-1],
+                verbose,
             )
-        return _find_matching_asset(asset_pattern, assets)
+        return _find_matching_asset(asset_pattern, assets, verbose)
 
-    def skip_download(self, config: Config, force: bool) -> bool:
+    def skip_download(self, config: Config, force: bool, verbose: bool = False) -> bool:
         """Check if download should be skipped (binary already exists)."""
         tool_info = config.manifest.get_tool_info(
             self.tool_config.tool_name,
@@ -418,12 +424,13 @@ class BinSpec:
         )
         if tool_info and tool_info["tag"] == self.tag and all_exist and not force:
             dt = humanize_time_ago(tool_info["updated_at"])
-            log(
-                f"[b]{self.tool_config.tool_name} {self.tag}[/] for"
-                f" [b]{self.platform}/{self.arch}[/] is already up to date"
-                f" (installed [b]{dt}[/] ago) use --force to re-download.",
-                "success",
-            )
+            if verbose:
+                log(
+                    f"[b]{self.tool_config.tool_name} {self.tag}[/] for"
+                    f" [b]{self.platform}/{self.arch}[/] is already up to date"
+                    f" (installed [b]{dt}[/] ago) use --force to re-download.",
+                    "success",
+                )
             return True
         return False
 
@@ -751,16 +758,18 @@ def _maybe_asset_pattern(
     tag: str,
     tool_platform: str,
     tool_arch: str,
+    verbose: bool = False,
 ) -> str | None:
     """Get the formatted asset pattern for the tool."""
     # asset_pattern might not contain an entry if `--current` is used
     search_pattern = tool_config.asset_patterns.get(platform, {}).get(arch)
     if search_pattern is None:
-        log(
-            f"No [b]asset_pattern[/] provided for [b]{platform}/{arch}[/]",
-            "info",
-            "ℹ️",  # noqa: RUF001
-        )
+        if verbose:
+            log(
+                f"No [b]asset_pattern[/] provided for [b]{platform}/{arch}[/]",
+                "info",
+                "ℹ️",  # noqa: RUF001
+            )
         return None
     version = tag_to_version(tag)
     return (
@@ -909,9 +918,11 @@ def _auto_detect_asset(
     defaults: DefaultsDict,
     tool_name: str,
     repo_name: str | None = None,
+    verbose: bool = False,
 ) -> _AssetDict | None:
     """Auto-detect an asset for the tool."""
-    log(f"Auto-detecting asset for [b]{platform}/{arch}[/]", "info")
+    if verbose:
+        log(f"Auto-detecting asset for [b]{platform}/{arch}[/]", "info")
     name_hints = _normalize_name_hints(tool_name, repo_name)
     detect_fn = create_system_detector(
         platform,
@@ -927,39 +938,49 @@ def _auto_detect_asset(
             assert candidates is not None
             asset_name = _select_candidate(candidates, name_hints)
             if asset_name != candidates[0]:
-                log(
-                    f"Found multiple candidates: {candidates}, selecting `{asset_name}`"
-                    " because it best matches the tool name",
-                    "info",
-                )
-            else:
+                if verbose:
+                    log(
+                        f"Found multiple candidates: {candidates}, selecting `{asset_name}`"
+                        " because it best matches the tool name",
+                        "info",
+                    )
+            elif verbose:
                 log(f"Found multiple candidates: {candidates}, selecting first", "info")
         elif candidates and tool_name in candidates:
-            log(
-                f"Found multiple candidates: {candidates}, selecting `{tool_name}`"
-                " because it perfectly matches the tool name",
-                "info",
-            )
+            if verbose:
+                log(
+                    f"Found multiple candidates: {candidates}, selecting `{tool_name}`"
+                    " because it perfectly matches the tool name",
+                    "info",
+                )
             asset_name = tool_name
         else:
-            if candidates:
-                log(f"Found multiple candidates: {candidates}, manually select one", "info", "⁉️")
+            if candidates and verbose:
+                log(
+                    f"Found multiple candidates: {candidates}, manually select one",
+                    "info",
+                    "⁉️",
+                )
             log(f"Error detecting asset: {err}", "error")
             return None
     asset = assets[asset_names.index(asset_name)]
-    log(f"Found asset: {asset['name']}", "success")
+    if verbose:
+        log(f"Found asset: {asset['name']}", "success")
     return asset
 
 
 def _find_matching_asset(
     asset_pattern: str,
     assets: list[_AssetDict],
+    verbose: bool = False,
 ) -> _AssetDict | None:
     """Find a matching asset for the tool."""
-    log(f"Looking for asset with pattern: {asset_pattern}", "info")
+    if verbose:
+        log(f"Looking for asset with pattern: {asset_pattern}", "info")
     for asset in assets:
         if re.search(asset_pattern, asset["name"]):
-            log(f"Found matching asset: {asset['name']}", "success")
+            if verbose:
+                log(f"Found matching asset: {asset['name']}", "success")
             return asset
     log(f"No asset matching '{asset_pattern}' found in {assets}", "warning")
     return None
@@ -980,6 +1001,7 @@ def _fetch_release(
             tool_config.tag_pattern,
             github_token,
             api_url=tool_config.api_url,
+            verbose=verbose,
         )
         tool_config._release_info = release_info
     except Exception as e:

--- a/dotbins/download.py
+++ b/dotbins/download.py
@@ -33,15 +33,17 @@ def _extract_binary_from_archive(
     verbose: bool,
 ) -> None:
     """Extract binaries from an archive."""
-    log(f"Extracting from {archive_path} for {bin_spec.platform}", "info", "📦")
+    if verbose:
+        log(f"Extracting from {archive_path} for {bin_spec.platform}", "info", "📦")
     temp_dir = Path(tempfile.mkdtemp())
 
     try:
         extract_archive(archive_path, temp_dir)
-        log(f"Archive extracted to {temp_dir}", "success", "📦")
-        _log_extracted_files(temp_dir)
-        paths_in_archive = _detect_paths_in_archive(temp_dir, bin_spec.tool_config)
-        _process_binaries(temp_dir, destination_dir, paths_in_archive, bin_spec)
+        if verbose:
+            log(f"Archive extracted to {temp_dir}", "success", "📦")
+        _log_extracted_files(temp_dir, verbose)
+        paths_in_archive = _detect_paths_in_archive(temp_dir, bin_spec.tool_config, verbose)
+        _process_binaries(temp_dir, destination_dir, paths_in_archive, bin_spec, verbose)
 
     except Exception as e:
         log(f"Error extracting archive: {e}", "error", print_exception=verbose)
@@ -54,11 +56,12 @@ class AutoDetectBinaryPathsError(Exception):
     """Error raised when auto-detecting binary paths fails."""
 
 
-def _detect_paths_in_archive(temp_dir: Path, tool_config: ToolConfig) -> list[Path]:
+def _detect_paths_in_archive(temp_dir: Path, tool_config: ToolConfig, verbose: bool) -> list[Path]:
     """Auto-detect binary paths if not specified in configuration."""
     if tool_config.path_in_archive:
         return tool_config.path_in_archive
-    log("Binary path not specified, attempting auto-detection...", "info")
+    if verbose:
+        log("Binary path not specified, attempting auto-detection...", "info")
     binary_names = tool_config.binary_name
     paths_in_archive = auto_detect_paths_in_archive(temp_dir, binary_names)
     if not paths_in_archive:
@@ -66,7 +69,8 @@ def _detect_paths_in_archive(temp_dir: Path, tool_config: ToolConfig) -> list[Pa
         log(msg, "error")
         raise AutoDetectBinaryPathsError(msg)
     names = ", ".join(f"[b]{p}[/]" for p in paths_in_archive)
-    log(f"Auto-detected binary paths: {names}", "success")
+    if verbose:
+        log(f"Auto-detected binary paths: {names}", "success")
     return paths_in_archive
 
 
@@ -75,6 +79,7 @@ def _process_binaries(
     destination_dir: Path,
     paths_in_archive: list[Path],
     bin_spec: BinSpec,
+    verbose: bool,
 ) -> None:
     """Process each binary by finding it and copying to destination."""
     for path_in_archive, binary_name in zip(paths_in_archive, bin_spec.tool_config.binary_name):
@@ -85,11 +90,13 @@ def _process_binaries(
             bin_spec.tool_arch,
             bin_spec.tool_platform,
         )
-        _copy_binary_to_destination(source_path, destination_dir, binary_name)
+        _copy_binary_to_destination(source_path, destination_dir, binary_name, verbose)
 
 
-def _log_extracted_files(temp_dir: Path) -> None:
+def _log_extracted_files(temp_dir: Path, verbose: bool) -> None:
     """Log the extracted files for debugging."""
+    if not verbose:
+        return
     log("Extracted files:", "info", "ℹ️")  # noqa: RUF001
     for item in temp_dir.glob("**/*"):
         log(f"  - {item.relative_to(temp_dir)}", "info", "")
@@ -124,6 +131,7 @@ def _copy_binary_to_destination(
     source_path: Path,
     destination_dir: Path,
     binary_name: str,
+    verbose: bool = False,
 ) -> None:
     """Copy the binary to its destination and set permissions."""
     destination_dir.mkdir(parents=True, exist_ok=True)
@@ -137,7 +145,8 @@ def _copy_binary_to_destination(
         dest_path.chmod(dest_path.stat().st_mode)
     else:
         dest_path.chmod(dest_path.stat().st_mode | 0o755)
-    log(f"Copied binary to [b]{replace_home_in_path(dest_path, '~')}[/]", "success")
+    if verbose:
+        log(f"Copied binary to [b]{replace_home_in_path(dest_path, '~')}[/]", "success")
 
 
 def _replace_variables_in_path(path: str, tag: str, arch: str, platform: str) -> str:
@@ -203,7 +212,7 @@ def _prepare_download_task(
             # Means we failed to fetch the release info
             return None
         bin_spec = tool_config.bin_spec(arch, platform)
-        if bin_spec.skip_download(config, force):
+        if bin_spec.skip_download(config, force, verbose):
             config._update_summary.add_skipped_tool(
                 tool_name,
                 platform,
@@ -212,7 +221,7 @@ def _prepare_download_task(
                 reason="Already up-to-date",
             )
             return None
-        asset = bin_spec.matching_asset()
+        asset = bin_spec.matching_asset(verbose)
         if asset is None:
             config._update_summary.add_failed_tool(
                 tool_name,
@@ -267,7 +276,11 @@ def prepare_download_tasks(
     for tool_name in tools_to_sync:
         for platform in platforms_to_sync:
             if current:
-                log(f"Including current platform [b]{platform}[/] even if not configured", "info")
+                if verbose:
+                    log(
+                        f"Including current platform [b]{platform}[/] even if not configured",
+                        "info",
+                    )
             elif platform not in config.platforms:
                 config._update_summary.add_skipped_tool(
                     tool_name,
@@ -279,7 +292,13 @@ def prepare_download_tasks(
                 log(f"Skipping unknown platform: {platform}", "warning")
                 continue
 
-            archs_to_update = _determine_architectures(platform, architecture, config, current)
+            archs_to_update = _determine_architectures(
+                platform,
+                architecture,
+                config,
+                current,
+                verbose,
+            )
             if not archs_to_update:
                 config._update_summary.add_skipped_tool(
                     tool_name,
@@ -306,16 +325,55 @@ def _download_task(
 ) -> bool:
     """Download a file for a DownloadTask."""
     try:
-        log(
-            f"Downloading [b]{task.asset_name}[/] for [b]{task.tool_name}[/] ([b]{task.platform}/{task.arch}[/])...",
-            "info",
-            "📥",
-        )
+        if verbose:
+            log(
+                f"Downloading [b]{task.asset_name}[/] for [b]{task.tool_name}[/] ([b]{task.platform}/{task.arch}[/])...",
+                "info",
+                "📥",
+            )
         download_file(task.asset_url, str(task.temp_path), github_token, verbose)
         return True
     except Exception as e:
         log(f"Error downloading {task.asset_name}: {e!s}", "error", print_exception=verbose)
         return False
+
+
+def _log_sha256(sha256_hash: str, verbose: bool) -> None:
+    if verbose:
+        log(f"SHA256: {sha256_hash}", "info", "🔐")
+
+
+def _log_auto_detected_extract_archive(
+    tool_name: str,
+    extract_archive: bool,
+    verbose: bool,
+) -> None:
+    if verbose:
+        log(
+            f"Auto-detected [b]extract_archive[/] for [b]{tool_name}[/]: {extract_archive}",
+            "info",
+            "🔍",
+        )
+
+
+def _copy_non_archive_binary(task: _DownloadTask, summary: UpdateSummary, verbose: bool) -> bool:
+    binary_names = task.tool_config.binary_name
+    if len(binary_names) != 1:
+        log(
+            f"Expected exactly one binary name for {task.tool_name}, got {len(binary_names)}",
+            "error",
+        )
+        summary.add_failed_tool(
+            task.tool_name,
+            task.platform,
+            task.arch,
+            task.tag,
+            reason="Expected exactly one binary name",
+        )
+        return False
+
+    _copy_binary_to_destination(task.temp_path, task.destination_dir, binary_names[0], verbose)
+    return True
 
 
 def download_files_in_parallel(
@@ -326,7 +384,8 @@ def download_files_in_parallel(
     """Download files in parallel."""
     if not download_tasks:
         return []
-    log(f"Downloading {len(download_tasks)} tools in parallel...", "info", "🔄")
+    if verbose:
+        log(f"Downloading {len(download_tasks)} tools in parallel...", "info", "🔄")
     func = partial(_download_task, github_token=github_token, verbose=verbose)
     return execute_in_parallel(download_tasks, func, 16)
 
@@ -352,17 +411,13 @@ def _process_downloaded_task(
     try:
         # Calculate SHA256 hash before extraction
         sha256_hash = calculate_sha256(task.temp_path)
-        log(f"SHA256: {sha256_hash}", "info", "🔐")
+        _log_sha256(sha256_hash, verbose)
 
         task.destination_dir.mkdir(parents=True, exist_ok=True)
         extract_archive = task.tool_config.extract_archive
         if extract_archive is None:
             extract_archive = auto_detect_extract_archive(str(task.temp_path))
-            log(
-                f"Auto-detected [b]extract_archive[/] for [b]{task.tool_name}[/]: {extract_archive}",
-                "info",
-                "🔍",
-            )
+            _log_auto_detected_extract_archive(task.tool_name, extract_archive, verbose)
 
         if extract_archive:
             _extract_binary_from_archive(
@@ -371,30 +426,17 @@ def _process_downloaded_task(
                 task.bin_spec,
                 verbose,
             )
-        else:
-            binary_names = task.tool_config.binary_name
-            if len(binary_names) != 1:
-                log(
-                    f"Expected exactly one binary name for {task.tool_name}, got {len(binary_names)}",
-                    "error",
-                )
-                summary.add_failed_tool(
-                    task.tool_name,
-                    task.platform,
-                    task.arch,
-                    task.tag,
-                    reason="Expected exactly one binary name",
-                )
-                return False
-            binary_name = binary_names[0]
-            _copy_binary_to_destination(task.temp_path, task.destination_dir, binary_name)
+        elif not _copy_non_archive_binary(task, summary, verbose):
+            return False
     except Exception as e:
         # Differentiate error types for better reporting
-        error_prefix = "Error processing"
-        if isinstance(e, AutoDetectBinaryPathsError):
-            error_prefix = "Auto-detect binary paths error"
-        elif isinstance(e, FileNotFoundError):
-            error_prefix = "Binary not found"
+        error_prefix = (
+            "Auto-detect binary paths error"
+            if isinstance(e, AutoDetectBinaryPathsError)
+            else "Binary not found"
+            if isinstance(e, FileNotFoundError)
+            else "Error processing"
+        )
         log(f"Error processing {task.tool_name}: {e!s}", "error", print_exception=verbose)
         summary.add_failed_tool(
             task.tool_name,
@@ -421,10 +463,11 @@ def _process_downloaded_task(
             url=task.asset_url,
         )
 
-        log(
-            f"Successfully installed [b]{task.tool_name} {task.tag}[/] for [b]{task.platform}/{task.arch}[/]",
-            "success",
-        )
+        if verbose:
+            log(
+                f"Successfully installed [b]{task.tool_name} {task.tag}[/] for [b]{task.platform}/{task.arch}[/]",
+                "success",
+            )
         return True
     finally:
         if task.temp_path.exists():
@@ -441,7 +484,8 @@ def process_downloaded_files(
     """Process downloaded files."""
     if not download_successes:
         return
-    log(f"Processing {len(download_successes)} downloaded tools...", "info", "🔄")
+    if verbose:
+        log(f"Processing {len(download_successes)} downloaded tools...", "info", "🔄")
     for task, download_success in zip(download_tasks, download_successes):
         _process_downloaded_task(task, download_success, manifest, summary, verbose)
 
@@ -451,11 +495,16 @@ def _determine_architectures(
     architecture: str | None,
     config: Config,
     current: bool,
+    verbose: bool = False,
 ) -> list[str]:
     """Determine which architectures to update for a platform."""
     if current:
         assert architecture is not None
-        log(f"Including current architecture [b]{architecture}[/] even if not configured", "info")
+        if verbose:
+            log(
+                f"Including current architecture [b]{architecture}[/] even if not configured",
+                "info",
+            )
         return [architecture]
     if architecture is not None:
         # Filter to only include the specified architecture if it's supported

--- a/dotbins/utils.py
+++ b/dotbins/utils.py
@@ -89,6 +89,7 @@ def fetch_release_info(
     tag_pattern: str | None = None,
     github_token: str | None = None,
     api_url: str | None = None,
+    verbose: bool = False,
 ) -> dict | None:
     """Fetch release information from a GitHub-compatible API for a single repository.
 
@@ -101,6 +102,7 @@ def fetch_release_info(
         github_token: GitHub API token for authentication
         api_url: Base API URL (default: "https://api.github.com").
             For Gitea/Forgejo, use e.g. "https://gitea.com/api/v1".
+        verbose: Whether to emit request/selection logs.
 
     Returns:
         Release information dict from GitHub-compatible API
@@ -111,18 +113,24 @@ def fetch_release_info(
 
     if tag is not None:
         url = f"{base}/repos/{repo}/releases/tags/{tag}"
-        log(f"Fetching release from {url}", "info")
+        if verbose:
+            log(f"Fetching release from {url}", "info")
     elif tag_pattern is not None:
         # Fetch releases and find first matching the pattern
         url = f"{base}/repos/{repo}/releases?per_page=30"
-        log(f"Fetching releases matching pattern '{tag_pattern}' from {url}", "info")
+        if verbose:
+            log(f"Fetching releases matching pattern '{tag_pattern}' from {url}", "info")
         try:
             response = _github_api_get(url, headers)
             response.raise_for_status()
             releases = response.json()
             for release in releases:
                 if re.search(tag_pattern, release["tag_name"]):
-                    log(f"Found release matching '{tag_pattern}': {release['tag_name']}", "success")
+                    if verbose:
+                        log(
+                            f"Found release matching '{tag_pattern}': {release['tag_name']}",
+                            "success",
+                        )
                     return release
             msg = f"No release matching pattern '{tag_pattern}' found in {repo}"
             raise RuntimeError(msg)
@@ -131,7 +139,8 @@ def fetch_release_info(
             raise RuntimeError(msg) from e
     else:
         url = f"{base}/repos/{repo}/releases/latest"
-        log(f"Fetching release from {url}", "info")
+        if verbose:
+            log(f"Fetching release from {url}", "info")
 
     try:
         response = _github_api_get(url, headers)
@@ -144,7 +153,8 @@ def fetch_release_info(
 
 def download_file(url: str, destination: str, github_token: str | None, verbose: bool) -> str:
     """Download a file from a URL to a destination path."""
-    log(f"Downloading from [b]{url}[/]", "info", "📥")
+    if verbose:
+        log(f"Downloading from [b]{url}[/]", "info", "📥")
     # Already verbose when fetching release info
     headers = _maybe_github_token_header(github_token)
     try:

--- a/tests/download_release_jsons.py
+++ b/tests/download_release_jsons.py
@@ -4,6 +4,9 @@
 This script will download the JSON from the latest GitHub release for each tool
 listed in examples/examples.yaml and save it to tests/release_jsons/.
 """
+
+from __future__ import annotations
+
 # /// script
 # dependencies = [
 #   "requests",
@@ -11,7 +14,6 @@ listed in examples/examples.yaml and save it to tests/release_jsons/.
 #   "dotbins",
 # ]
 # ///
-
 import json
 import os
 import sys
@@ -22,7 +24,6 @@ import yaml
 
 # Add parent directory to path so we can import dotbins
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from dotbins.utils import _maybe_github_token_header
 
 # Extra repos that power tests but are not part of the public examples file.
 EXTRA_TOOLS = {
@@ -38,64 +39,80 @@ RELEASES_LIST_TOOLS = {
 }
 
 
-def main() -> None:
-    """Download release JSONs for all tools in examples.yaml."""
-    # Ensure release_jsons directory exists
+def _release_jsons_dir() -> Path:
+    """Return the directory used to store cached release JSONs."""
     release_jsons_dir = Path(__file__).parent / "release_jsons"
     release_jsons_dir.mkdir(exist_ok=True)
+    return release_jsons_dir
 
-    # Read examples.yaml
+
+def _load_tools() -> dict[str, str | dict[str, str]]:
+    """Load tool definitions from examples.yaml plus test-only extras."""
     examples_yaml = Path(__file__).parent.parent / "examples" / "examples.yaml"
     with open(examples_yaml) as f:
         config = yaml.safe_load(f)
 
-    # Get GitHub token if available
-    github_token = os.environ.get("GITHUB_TOKEN")
-    headers = _maybe_github_token_header(github_token)
-
-    # Process each tool
     tools = dict(config.get("tools", {}))
     tools.update(EXTRA_TOOLS)
-    total = len(tools)
+    return tools
 
+
+def _github_headers() -> dict[str, str]:
+    """Build GitHub headers using the optional token from the environment."""
+    from dotbins.utils import _maybe_github_token_header
+
+    github_token = os.environ.get("GITHUB_TOKEN")
+    return _maybe_github_token_header(github_token)
+
+
+def _download_json(url: str, destination: Path, headers: dict[str, str]) -> list | dict:
+    """Fetch JSON data and write it to disk."""
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    with open(destination, "w") as f:
+        json.dump(data, f, indent=2)
+
+    return data
+
+
+def _download_tool_release_jsons(
+    release_jsons_dir: Path,
+    tools: dict[str, str | dict[str, str]],
+    headers: dict[str, str],
+) -> None:
+    """Download latest-release JSON blobs for each configured tool."""
+    total = len(tools)
     print(f"Downloading release JSONs for {total} tools...")
 
     for i, (tool_name, value) in enumerate(tools.items(), 1):
-        # Skip if already downloaded
         json_file = release_jsons_dir / f"{tool_name}.json"
         if json_file.exists():
             print(f"[{i}/{total}] Skipping {tool_name} (already downloaded)")
             continue
 
-        # Get repo
         repo = value if isinstance(value, str) else value.get("repo")
         if not repo:
             print(f"[{i}/{total}] Skipping {tool_name} (no repo found)")
             continue
 
-        # Fetch release info
         print(f"[{i}/{total}] Downloading {tool_name} from {repo}...")
-        if "tag" in value:
-            url = f"https://api.github.com/repos/{repo}/releases/tags/{value['tag']}"
-        else:
-            url = f"https://api.github.com/repos/{repo}/releases/latest"
+        url = (
+            f"https://api.github.com/repos/{repo}/releases/tags/{value['tag']}"
+            if isinstance(value, dict) and "tag" in value
+            else f"https://api.github.com/repos/{repo}/releases/latest"
+        )
 
         try:
-            response = requests.get(url, headers=headers, timeout=30)
-            response.raise_for_status()
-            release_data = response.json()
-
-            # Save to file
-            with open(json_file, "w") as f:
-                json.dump(release_data, f, indent=2)
-
+            _download_json(url, json_file, headers)
             print(f"[{i}/{total}] Downloaded {tool_name}")
         except requests.RequestException as e:
             print(f"[{i}/{total}] Error downloading {tool_name}: {e}")
 
-    print(f"\nDownloaded release JSONs to {release_jsons_dir}")
 
-    # Download releases lists for tools that need tag_pattern testing
+def _download_release_lists(release_jsons_dir: Path, headers: dict[str, str]) -> None:
+    """Download full release lists for repos that need tag-pattern tests."""
     print(f"\nDownloading releases lists for {len(RELEASES_LIST_TOOLS)} tools...")
     for tool_name, config in RELEASES_LIST_TOOLS.items():
         json_file = release_jsons_dir / f"{tool_name}_releases.json"
@@ -109,16 +126,21 @@ def main() -> None:
 
         print(f"Downloading releases list for {tool_name} from {repo}...")
         try:
-            response = requests.get(url, headers=headers, timeout=30)
-            response.raise_for_status()
-            releases_data = response.json()
-
-            with open(json_file, "w") as f:
-                json.dump(releases_data, f, indent=2)
-
+            releases_data = _download_json(url, json_file, headers)
             print(f"Downloaded {tool_name}_releases.json ({len(releases_data)} releases)")
         except requests.RequestException as e:
             print(f"Error downloading releases for {tool_name}: {e}")
+
+
+def main() -> None:
+    """Download release JSONs for all tools in examples.yaml."""
+    release_jsons_dir = _release_jsons_dir()
+    tools = _load_tools()
+    headers = _github_headers()
+
+    _download_tool_release_jsons(release_jsons_dir, tools, headers)
+    print(f"\nDownloaded release JSONs to {release_jsons_dir}")
+    _download_release_lists(release_jsons_dir, headers)
 
 
 if __name__ == "__main__":

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -314,7 +314,7 @@ def test_e2e_sync_tools(
         return destination
 
     with patch("dotbins.download.download_file", side_effect=mock_download_file):
-        config.sync_tools()
+        config.sync_tools(verbose=True)
 
     verify_binaries_installed(config)
 
@@ -370,7 +370,9 @@ def test_e2e_sync_tools_skip_up_to_date(
 
     # Check that no download was attempted
     out = capsys.readouterr().out
-    assert "--force to re-download" in out
+    assert "--force to re-download" not in out
+    assert "Skipped Tools" in out
+    assert "Already up-to-date" in out
 
 
 def test_e2e_sync_tools_partial_skip_and_update(
@@ -588,6 +590,7 @@ def test_get_tool_command(tmp_path: Path, create_dummy_archive: Callable) -> Non
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
         api_url: str | None = None,  # noqa: ARG001
+        verbose: bool = False,  # noqa: ARG001
     ) -> dict:
         return {
             "tag_name": "v1.0.0",
@@ -706,6 +709,7 @@ def test_get_tool_command_with_remote_config(
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
         api_url: str | None = None,  # noqa: ARG001
+        verbose: bool = False,  # noqa: ARG001
     ) -> dict:
         log(f"Getting release info for repo: {repo}", "info")
         tool_name = repo.split("/")[-1]
@@ -777,6 +781,7 @@ def test_get_tool_command_with_local_config(
         tag_pattern: str | None = None,  # noqa: ARG001
         github_token: str | None = None,  # noqa: ARG001
         api_url: str | None = None,  # noqa: ARG001
+        verbose: bool = False,  # noqa: ARG001
     ) -> dict:
         log(f"Getting release info for repo: {repo}", "info")
         tool_name = repo.split("/")[-1]
@@ -961,7 +966,8 @@ def test_non_extract_with_multiple_binary_names(
     # The summary will be displayed at the end of the update process
     assert "Expected exactly one binary name" in captured.out
     assert "multi-bin-tool" in captured.out
-    assert "linux/amd64" in captured.out
+    assert "linux" in captured.out
+    assert "amd64" in captured.out
 
     # Verify that no binary files were created
     bin_dir = config.bin_dir("linux", "amd64")
@@ -1017,8 +1023,9 @@ def test_non_extract_single_binary_copy(
     # Capture the output
     captured = capsys.readouterr()
 
-    # Verify successful messages in the output
-    assert "Successfully installed single-bin-tool" in captured.out
+    # Default sync output should stay summary-focused.
+    assert "Successfully installed single-bin-tool" not in captured.out
+    assert "Updated Tools" in captured.out
 
     # Verify that the binary file was created with the correct name
     bin_dir = config.bin_dir("linux", "amd64")
@@ -1062,7 +1069,7 @@ def test_error_preparing_download(
     config.tools["error-tool"]._release_info = {"tag_name": "v1.0.0", "assets": []}
 
     # Create a BinSpec.matching_asset method that raises an exception
-    def mock_matching_asset(self) -> NoReturn:  # noqa: ANN001, ARG001
+    def mock_matching_asset(self, verbose: bool = False) -> NoReturn:  # noqa: ANN001, ARG001
         msg = "Simulated error in matching asset"
         raise RuntimeError(msg)
 
@@ -1141,7 +1148,7 @@ def test_binary_not_found_error_handling(
         return destination
 
     with patch("dotbins.download.download_file", side_effect=mock_download_file):
-        config.sync_tools()
+        config.sync_tools(verbose=True)
 
     # Capture the output
     captured = capsys.readouterr()
@@ -1328,7 +1335,7 @@ def test_no_matching_asset(
     )
     config.tools["mytool"]._release_info = {"tag_name": "v1.0.0", "assets": []}
 
-    config.sync_tools()
+    config.sync_tools(verbose=True)
 
     # Capture the output
     captured = capsys.readouterr()
@@ -1340,7 +1347,7 @@ def test_no_matching_asset(
 def test_no_tools(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Test syncing with no tools."""
     config = Config(tools_dir=tmp_path)
-    config.sync_tools()
+    config.sync_tools(verbose=True)
 
     captured = capsys.readouterr()
     assert "No tools configured" in captured.out
@@ -1384,7 +1391,7 @@ def test_auto_detect_asset_multiple_perfect_matches(
         return destination
 
     with patch("dotbins.download.download_file", side_effect=mock_download_file):
-        config.sync_tools()
+        config.sync_tools(verbose=True)
 
     out = capsys.readouterr().out
     assert "Found multiple candidates" in out
@@ -1433,7 +1440,7 @@ def test_auto_detect_asset_prefers_primary_tool_binary(
         return destination
 
     with patch("dotbins.download.download_file", side_effect=mock_download_file):
-        config.sync_tools()
+        config.sync_tools(verbose=True)
 
     out = capsys.readouterr().out
     assert "Found multiple candidates" in out
@@ -1478,7 +1485,7 @@ def test_auto_detect_asset_deprioritizes_unknown_variant_tokens(
         return destination
 
     with patch("dotbins.download.download_file", side_effect=mock_download_file):
-        config.sync_tools()
+        config.sync_tools(verbose=True)
 
     out = capsys.readouterr().out
     assert "Found multiple candidates" in out
@@ -1566,7 +1573,7 @@ def test_auto_detect_asset_no_matches(
         {"linux": ["amd64", "i386"]},  # Different arch
     )
 
-    config.sync_tools()
+    config.sync_tools(verbose=True)
 
     out = capsys.readouterr().out
     assert "Found multiple candidates" in out, out
@@ -1609,7 +1616,7 @@ def test_e2e_auto_detect_no_candidates(
 
     # Check log output for the specific error
     out = capsys.readouterr().out
-    assert "Auto-detecting asset for linux/amd64" in out, out
+    assert "Auto-detecting asset for linux/amd64" not in out, out
     assert "Error detecting asset: no candidates found" in out
 
     # Check failure summary
@@ -2057,8 +2064,8 @@ def test_tool_with_custom_tag(
     # Capture the output
     out = capsys.readouterr().out
 
-    # Verify successful messages in the output
-    assert "Successfully installed tool" in out
+    assert "Successfully installed tool" not in out
+    assert "Updated Tools" in out
 
     # Verify that the binary file was created with the correct name
     bin_dir = config.bin_dir("linux", "amd64")
@@ -2125,8 +2132,8 @@ def test_tool_with_custom_shell_code(
     # Capture the output
     out = capsys.readouterr().out
 
-    # Verify successful messages in the output
-    assert "Successfully installed tool" in out
+    assert "Successfully installed tool" not in out
+    assert "Updated Tools" in out
     assert "unknown shell" in out
 
     # Verify that the shell scripts were generated correctly

--- a/tests/test_release_patterns.py
+++ b/tests/test_release_patterns.py
@@ -4,10 +4,11 @@ import json
 import re
 import sys
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from dotbins.config import build_tool_config
+from dotbins.config import RawToolConfigDict, build_tool_config
 
 CASES = [
     ("atuin", "linux", "amd64", "atuin-x86_64-unknown-linux-musl.tar.gz"),
@@ -397,14 +398,19 @@ def test_tag_pattern_filtering() -> None:
         "prefer_appimage": True,
     }
 
+    raw_data: RawToolConfigDict = {
+        "repo": "bitwarden/clients",
+        "tag_pattern": tag_pattern,
+        # Use regex pattern since Bitwarden's version in assets differs from tag
+        "asset_patterns": cast(
+            "dict[str, dict[str, str | None]]",
+            {"macos": {"arm64": r"bw-macos-arm64-\d+\.\d+\.\d+\.zip"}},
+        ),
+    }
+
     tool_config = build_tool_config(
         tool_name="bw",
-        raw_data={
-            "repo": "bitwarden/clients",
-            "tag_pattern": tag_pattern,
-            # Use regex pattern since Bitwarden's version in assets differs from tag
-            "asset_patterns": {"macos": {"arm64": r"bw-macos-arm64-\d+\.\d+\.\d+\.zip"}},
-        },
+        raw_data=raw_data,
         platforms={"macos": ["arm64"]},
         defaults=defaults,  # type: ignore[arg-type]
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -320,6 +320,7 @@ class TestFetchReleaseInfoTagPattern:
 
             # Pattern to exclude prereleases
             result = fetch_release_info("owner/repo", tag_pattern=r"^v\d+\.\d+\.\d+$")
+            assert result is not None
             assert result["tag_name"] == "v1.0.0"
 
     def test_tag_pattern_network_error(self) -> None:


### PR DESCRIPTION
## Summary
- keep `dotbins sync` output summary-focused by default
- thread `verbose` explicitly through release, asset-selection, and download helpers
- update tests to cover quiet-by-default output and verbose diagnostics

## Testing
- `uv run ruff check dotbins/config.py dotbins/download.py dotbins/utils.py tests/test_e2e.py`
- `uv run pytest tests/test_cli.py tests/test_config_validation.py tests/test_defaults.py tests/test_detect_asset.py tests/test_detect_binary.py tests/test_e2e.py tests/test_from_tools.py tests/test_manifest.py tests/test_readme_generation.py tests/test_summary.py tests/test_unit.py tests/test_utils.py tests/test_windows_skip_download.py -q --no-cov`

Fixes #163